### PR TITLE
Field width in scanf format string may case overflow

### DIFF
--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -86,19 +86,19 @@ gf_proc_dump_set_path (char *dump_options_file)
         if (!fp)
                 goto out;
 
-        ret = fscanf (fp, "%s", buf);
+        ret = fscanf (fp, "%255s", buf);
 
         while (ret != EOF) {
                 key = strtok_r (buf, "=", &saveptr);
                 if (!key) {
-                        ret = fscanf (fp, "%s", buf);
+                        ret = fscanf (fp, "%255s", buf);
                         continue;
                 }
 
                 value = strtok_r (NULL, "=", &saveptr);
 
                 if (!value) {
-                        ret = fscanf (fp, "%s", buf);
+                        ret = fscanf (fp, "%255s", buf);
                         continue;
                 }
                 if (!strcmp (key, "path")) {


### PR DESCRIPTION
no limitation for "%s" while calling fscanf()